### PR TITLE
Signup schema endpoints

### DIFF
--- a/src/app/api/signup/[signupId]/route.ts
+++ b/src/app/api/signup/[signupId]/route.ts
@@ -1,0 +1,45 @@
+import connectDB from "@/database/db";
+import { NextResponse } from "next/server";
+import Signup from "@/database/models/signupSchema";
+
+/**
+ * gets 1 signup from the database based on the signupId
+ * returns all signups in the database as a JSON response
+ * if an error occurs, returns a JSON response w
+      signupId: new ObjectId().toString(),ith an error message and status code 500
+ */
+
+type IParams = {
+  params: {
+    signupId: String;
+  };
+};
+
+export async function GET(request: Request, { params }: IParams): Promise<NextResponse> {
+  // Attempt to connect to the database
+  await connectDB();
+
+  const { signupId } = params;
+
+  try {
+    const signup = await Signup.findOne({ signupId: signupId });
+    // check if signup exists
+    if (!signup) {
+      return NextResponse.json({ message: "Signup not found." }, { status: 404 });
+    }
+    // if signup exists, return it
+    return NextResponse.json(
+      {
+        signup: signup,
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    console.error("Error fetching signup:", err);
+    return NextResponse.json({
+      message: "Failed to fetch signup.",
+      error: err instanceof Error ? err.message : "An unknown error occurred.",
+      status: 500,
+    });
+  }
+}

--- a/src/app/api/signup/route.ts
+++ b/src/app/api/signup/route.ts
@@ -1,6 +1,8 @@
 import connectDB from "@/database/db";
 import { NextResponse } from "next/server";
 import Signup from "@/database/models/signupSchema";
+import { ObjectId } from "mongodb";
+import { sign } from "crypto";
 
 /**
  * gets all signups from the database
@@ -54,11 +56,16 @@ export async function POST(request: Request): Promise<NextResponse> {
 
     for (const field of requiredFields) {
       if (!body[field]) {
+        // if waiver is false, it will be sent as "false" in the request body, which is a falsy value in JavaScript. To account for this, we need to check if the field is explicitly undefined rather than just falsy.
+        if (field === "waiver" && body[field] === false) {
+          continue; // skip the check for waiver if it's false
+        }
         return NextResponse.json({ message: `Missing required field: ${field}` }, { status: 400 });
       }
     }
 
     const newSignup = new Signup({
+      signupId: crypto.randomUUID(),
       shiftId: body.shiftId,
       profileId: body.profileId,
       waiver: body.waiver,

--- a/src/app/api/signup/route.ts
+++ b/src/app/api/signup/route.ts
@@ -1,0 +1,86 @@
+import connectDB from "@/database/db";
+import { NextResponse } from "next/server";
+import Signup from "@/database/models/signupSchema";
+
+/**
+ * gets all signups from the database
+ * returns all signups in the database as a JSON response
+ * if an error occurs, returns a JSON response with an error message and status code 500
+ */
+
+export async function GET(): Promise<NextResponse> {
+  // Attempt to connect to the database
+  await connectDB();
+
+  try {
+    const signups = await Signup.find();
+    return NextResponse.json(
+      {
+        signups: signups,
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    console.error("Error fetching signups:", err);
+    return NextResponse.json(
+      {
+        message: "Failed to fetch signups.",
+        error: err instanceof Error ? err.message : "An unknown error occurred.",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+/*
+ * creates a new signup in the database
+ * request must require the following fields: 
+ *  shiftId: string;
+    profileId: string;
+    waiver: boolean;
+ */
+
+export async function POST(request: Request): Promise<NextResponse> {
+  await connectDB();
+
+  try {
+    const body = await request.json();
+
+    // ensure required fields are present
+
+    // "timestamp" is not required in the request body because it will be generated automatically when the signup is created
+
+    const requiredFields = ["shiftId", "profileId", "waiver"];
+
+    for (const field of requiredFields) {
+      if (!body[field]) {
+        return NextResponse.json({ message: `Missing required field: ${field}` }, { status: 400 });
+      }
+    }
+
+    const newSignup = new Signup({
+      shiftId: body.shiftId,
+      profileId: body.profileId,
+      waiver: body.waiver,
+      timestamp: new Date(),
+    });
+
+    const saved = await newSignup.save();
+
+    return NextResponse.json(
+      {
+        signup: saved,
+      },
+      { status: 201 },
+    );
+  } catch (err) {
+    console.error("Error creating signup:", err);
+    return NextResponse.json(
+      {
+        message: "Failed to create signup.",
+        error: err instanceof Error ? err.message : "An unknown error occurred.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/database/models/signupSchema.ts
+++ b/src/database/models/signupSchema.ts
@@ -5,9 +5,11 @@ figma shows that liability form is yes/no
 so used a boolean for the waiver field. If it's true, the user has signed the waiver; if it's false, they haven't
 
 Using Date for timestamp because it will automatically store the date and time when the signup is created, which can be useful for tracking when users signed up for shifts.
+
  */
 
 type signup = {
+  signupId: String;
   shiftId: String;
   profileId: String;
   waiver: Boolean;
@@ -15,6 +17,7 @@ type signup = {
 };
 
 const signupSchema = new Schema<signup>({
+  signupId: { type: String, required: true },
   shiftId: { type: String, required: true },
   profileId: { type: String, required: true },
   waiver: { type: Boolean, required: true },

--- a/src/database/models/signupSchema.ts
+++ b/src/database/models/signupSchema.ts
@@ -1,0 +1,24 @@
+import mongoose, { Schema } from "mongoose";
+
+/* 
+figma shows that liability form is yes/no
+so used a boolean for the waiver field. If it's true, the user has signed the waiver; if it's false, they haven't
+ */
+
+type signup = {
+  shiftId: String;
+  profileId: String;
+  waiver: Boolean;
+  timestamp: String;
+};
+
+const signupSchema = new Schema<signup>({
+  shiftId: { type: String, required: true },
+  profileId: { type: String, required: true },
+  waiver: { type: Boolean, required: true },
+  timestamp: { type: String, required: true },
+});
+
+const Signup = mongoose.models["signup"] || mongoose.model("signup", signupSchema, "signup");
+
+export default Signup;

--- a/src/database/models/signupSchema.ts
+++ b/src/database/models/signupSchema.ts
@@ -3,20 +3,22 @@ import mongoose, { Schema } from "mongoose";
 /* 
 figma shows that liability form is yes/no
 so used a boolean for the waiver field. If it's true, the user has signed the waiver; if it's false, they haven't
+
+Using Date for timestamp because it will automatically store the date and time when the signup is created, which can be useful for tracking when users signed up for shifts.
  */
 
 type signup = {
   shiftId: String;
   profileId: String;
   waiver: Boolean;
-  timestamp: String;
+  timestamp: Date;
 };
 
 const signupSchema = new Schema<signup>({
   shiftId: { type: String, required: true },
   profileId: { type: String, required: true },
   waiver: { type: Boolean, required: true },
-  timestamp: { type: String, required: true },
+  timestamp: { type: Date, required: true },
 });
 
 const Signup = mongoose.models["signup"] || mongoose.model("signup", signupSchema, "signup");


### PR DESCRIPTION
## Developer: Alfredo Galicia

Closes #27 

### Pull Request Summary

- create signup schema
- create endpoints
    - get request for all signups
    - get request for day by signupId in params
    - post request to create signup


### Modifications

/database/models/signupSchema.ts
- created schema

/api/signup/route.ts
- get request for all signups
- post request to create a signup

/api/day/[signupId]/route.ts
- get request for single day by signupId

### Testing Considerations

All tested with postman

- get request success and error
- get request by params
    - success on valid signupId
    - 404 if signupId is not found
- post request
    - success if all fields are valid
    - 400 error if fields are missing

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="633" height="828" alt="getAll" src="https://github.com/user-attachments/assets/4b0e097f-fd55-48c6-b89d-9468beb93202" />
<img width="628" height="809" alt="getparamsId" src="https://github.com/user-attachments/assets/2a34fbea-1463-4c58-a199-b97f881f6c43" />
<img width="633" height="828" alt="postReq" src="https://github.com/user-attachments/assets/c6536b32-0105-42bf-a87f-59545df4b642" />
<img width="568" height="644" alt="schema" src="https://github.com/user-attachments/assets/5e3da16e-297d-4642-bf71-5bed90b97277" />
